### PR TITLE
fix(yaml_stripper.py): prevent the creation of a YAML file when the provided field does not exist.

### DIFF
--- a/YamlStripper/yaml_stripper.py
+++ b/YamlStripper/yaml_stripper.py
@@ -1,5 +1,6 @@
 import argparse
 import yaml
+import copy
 
 
 def remove_field(data, field):
@@ -29,8 +30,12 @@ def remove_fields(yaml_file, fields_to_remove, new_yaml_file):
     with open(yaml_file, 'r') as f:
         data = yaml.load(f, Loader=yaml.FullLoader)
 
+    old_yaml_data = copy.deepcopy(data)
     for field in fields_to_remove:
         remove_field(data, field)
+
+    if old_yaml_data == data:
+        return
 
     # Remove empty dictionary items
     data = {k:v for k, v in data.items() if v}

--- a/test/test_yaml_stripper.py
+++ b/test/test_yaml_stripper.py
@@ -1,12 +1,16 @@
 import os
+import pytest
 import yaml
 from tempfile import NamedTemporaryFile
-
 from yaml_stripper import remove_fields
 
 
-def test_remove_fields():
-    input_yaml = {'name': 'John', 'age': 30, 'hobbies': ['reading', 'writing', 'swimming']}
+@pytest.fixture
+def input_yaml():
+    return {'name': 'John', 'age': 30, 'hobbies': ['reading', 'writing', 'swimming']}
+
+
+def test_remove_fields(input_yaml):
     with NamedTemporaryFile(mode='w', delete=False) as f:
         yaml.dump(input_yaml, f)
 
@@ -17,5 +21,19 @@ def test_remove_fields():
         assert 'age' not in output_yaml
         assert output_yaml['name'] == 'John'
         assert output_yaml['hobbies'] == ['reading', 'writing', 'swimming']
+
+    os.remove(f.name)
+
+
+def test_should_not_create_a_file(input_yaml):
+    with NamedTemporaryFile(mode='w', delete=False) as f:
+        yaml.dump(input_yaml, f)
+
+    remove_fields(f.name, ['field_that_not_exists'], 'this_file_will_not_exist.yml')
+
+    with pytest.raises(FileNotFoundError) as exception:
+        with open('this_file_will_not_exist.yml', 'r') as f:
+            yaml.load(f, Loader=yaml.FullLoader)
+    assert str(exception.value) == "[Errno 2] No such file or directory: 'this_file_will_not_exist.yml'"
 
     os.remove(f.name)


### PR DESCRIPTION
Ao passar campos que não existam, o arquivo ainda assim é criado, como uma cópia do primeiro...